### PR TITLE
Implement `gnumake` rule with simple arguments.

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -13,13 +13,8 @@
 # limitations under the License.
 
 load("@gnumake//gnumake:gnumake.bzl", "gnumake_toolchain")
-load("@gnumake//gnumake:rules.bzl", "gnumake")
 
 gnumake_toolchain(
     name = "gnumake",
     visibility = ["PUBLIC"],
-)
-
-gnumake(
-    name = "example",
 )

--- a/examples/simple_makefile/BUCK
+++ b/examples/simple_makefile/BUCK
@@ -1,0 +1,7 @@
+load("@gnumake//gnumake:rules.bzl", "gnumake")
+
+gnumake(
+    name = "example",
+    srcs = ["Makefile"],
+    targets = ["all"],
+)

--- a/examples/simple_makefile/Makefile
+++ b/examples/simple_makefile/Makefile
@@ -1,0 +1,9 @@
+PREFIX ?= ${PWD}
+
+${PREFIX}:
+	mkdir -p $@
+
+${PREFIX}/out.txt: ${PREFIX}
+	echo "hello world" > $@
+
+all: ${PREFIX}/out.txt

--- a/gnumake/rules.bzl
+++ b/gnumake/rules.bzl
@@ -14,14 +14,91 @@
 
 load("@gnumake//gnumake:toolchain_info.bzl", "GNUMakeToolchainInfo")
 
-def _gnumake_impl(ctx: AnalysisContext):
+def _gnumake_impl(ctx: AnalysisContext) -> list:
+    """Implementation of rule `gnumake`."""
+    gnumake_bin = ctx.attrs._gnumake_toolchain[GNUMakeToolchainInfo].bin
+
+    install_dir = ctx.actions.declare_output(ctx.attrs.install_prefix, dir = True)
+
+    args = cmd_args()
+    args.add(cmd_args(install_dir.as_output(), format = "PREFIX={}"))
+    [args.add(arg) for arg in ctx.attrs.args]
+    [args.add(target) for target in ctx.attrs.targets]
+    [args.hidden(src) for src in ctx.attrs.srcs]
+    args.add(["-f", ctx.attrs.srcs[0]])
+
+    ctx.actions.run(
+        args,
+        category = "gnumake",
+        always_print_stderr = True,
+        exe = gnumake_bin,
+    )
+
     return [
-        DefaultInfo(),
+        DefaultInfo(default_output = install_dir),
     ]
 
 def _gnumake_attributes() -> dict[str, Attr]:
     return {
-        "_gnumake_toolchain": attrs.default_only(attrs.toolchain_dep(default = "@gnumake//:gnumake", providers = [GNUMakeToolchainInfo])),
+        "args": attrs.list(
+            attrs.arg(),
+            default = [],
+            doc = """
+    A list of arguments to forward to the call to GNUMake.
+""",
+        ),
+        "compiler_flags": attrs.list(
+            attrs.arg(),
+            default = [],
+            doc = """
+    Flags to use when compiling.
+""",
+        ),
+        "install_prefix": attrs.string(
+            default = "__install__",
+            doc = """
+    Install prefix path, relative to where to install the result of the build.
+This is passed an an argument to `make` as `PREFIX=<value>`.
+""",
+        ),
+        "platform_compiler_flags": attrs.list(
+            attrs.tuple(
+                attrs.regex(),
+                attrs.list(
+                    attrs.arg(),
+                    default = [],
+                    doc = """
+    Platform specific compiler flags. See `cxx_common.platform_compiler_flags_arg()` for more information.
+""",
+                ),
+            ),
+            default = [],
+            doc = """
+    Flags to use when compiling.
+""",
+        ),
+        "srcs": attrs.list(
+            attrs.source(),
+            doc = """
+    Input source.
+""",
+        ),
+        "targets": attrs.list(
+            attrs.string(),
+            default = ["", "install"],
+            doc = """
+    A list of targets to produce.
+""",
+        ),
+        "_gnumake_toolchain": attrs.default_only(
+            attrs.toolchain_dep(
+                default = "@gnumake//:gnumake",
+                providers = [GNUMakeToolchainInfo],
+            ),
+            doc = """
+    GNUMake toolchain.
+""",
+        ),
     }
 
 gnumake = rule(


### PR DESCRIPTION
Implement `gnumake` rule with simple arguments.

This commit aims to provide a first simple and straightforward implementation
of the `gnumake` rule.

The following flags are supported by this implementation:
 - [x] `args`: list of arguments to forward to the call to GNUMake.
 - [x] `install_prefix`: Name of the install directory, to be passed to `PREFIX`.
 - [ ] `compiler_flags`: compiler flags to use.
 - [ ] `platform_compiler_flags`: platform-specific compiler flags to use.
 - [x] `srcs`: Input files.
 - [x] `targets`: GNUMake targets to build.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/zadlg/buck2_rules_gnumake/pull/1).
* #10
* #9
* __->__ #1