### PR TITLE
Fix #13: add `makefile` attribute to `gnumake`.

### DIFF
--- a/examples/custom_makefile_file/BUCK
+++ b/examples/custom_makefile_file/BUCK
@@ -1,0 +1,8 @@
+load("@gnumake//gnumake:rules.bzl", "gnumake")
+
+gnumake(
+    name = "simple_makefile",
+    srcs = ["entry.makefile"],
+    makefile = "entry.makefile",
+    targets = ["all"],
+)

--- a/examples/custom_makefile_file/entry.makefile
+++ b/examples/custom_makefile_file/entry.makefile
@@ -1,0 +1,11 @@
+PREFIX?=${PWD}
+
+${PREFIX}:
+	mkdir -p $@
+
+${PREFIX}/hello.txt: ${PREFIX}
+	echo "hello world" > $@
+
+.PHONY: all
+
+all: ${PREFIX}/hello.txt

--- a/gnumake/rules.bzl
+++ b/gnumake/rules.bzl
@@ -78,6 +78,7 @@ def _gnumake_impl(ctx: AnalysisContext) -> list:
     )
     args = cmd_args()
     args.add(["-C", srcs_dir])
+    args.add(["-f", ctx.attrs.makefile])
     args.add(cmd_args(cmd_args(install_dir.as_output()).relative_to(srcs_dir), format = "PREFIX={}"))
     args.add(ctx.attrs.args)
     args.add(ctx.attrs.targets)
@@ -139,6 +140,12 @@ This is passed an an argument to `make` as `PREFIX=<value>`.
             doc = """
     Input source.
 """,
+        ),
+        "makefile": attrs.string(
+            default = "Makefile",
+            doc = """
+    The Makefile to use. This must contain the relative path to the Makefile.
+"""
         ),
         "targets": attrs.list(
             attrs.string(),


### PR DESCRIPTION
Fix #13: add `makefile` attribute to `gnumake`.

This commit adds a new string attribute to rule `gnumake` called `makefile`
to support a custom `Makefile` file.

An example has also been added.
