### PR TITLE
Fix #12: support platform-specific compiler flags.

### DIFF
--- a/examples/makefile_platform_compiler_flags/BUCK
+++ b/examples/makefile_platform_compiler_flags/BUCK
@@ -1,0 +1,22 @@
+load("@gnumake//gnumake:rules.bzl", "gnumake")
+
+gnumake(
+    name = "makefile_platform_compiler_flags",
+    srcs = ["Makefile", "a.c"],
+    compiler_flags = ["-DFLAG_ENABLED"],
+    platform_compiler_flags = [
+        (
+            "x86_64",
+            ["-DX86_64_FLAG_ENABLED"],
+        ),
+        (
+            "iphoneos",
+            ["-DIOS_FLAG_DISABLED"],
+        ),
+        (
+            "arm",
+            ["-DARM_FLAG_DISABLED"],
+        ),
+    ],
+    targets = ["install"],
+)

--- a/examples/makefile_platform_compiler_flags/Makefile
+++ b/examples/makefile_platform_compiler_flags/Makefile
@@ -1,0 +1,4 @@
+all: a.o
+
+install: a.o
+	mkdir ${PREFIX} && cp $^ ${PREFIX}/

--- a/examples/makefile_platform_compiler_flags/a.c
+++ b/examples/makefile_platform_compiler_flags/a.c
@@ -1,0 +1,17 @@
+void f() {
+#ifndef FLAG_ENABLED
+  error!
+#endif
+
+#ifndef X86_64_FLAG_ENABLED
+  error!
+#endif
+
+#ifdef IOS_FLAG_DISABLED
+  error!
+#endif
+
+#ifdef ARM_FLAG_DISABLED
+  error!
+#endif
+}

--- a/gnumake/rules.bzl
+++ b/gnumake/rules.bzl
@@ -14,6 +14,7 @@
 
 load("@gnumake//gnumake:toolchain_info.bzl", "GNUMakeToolchainInfo")
 load("@prelude//cxx:cxx_toolchain_types.bzl", "CxxToolchainInfo")
+load("@prelude//cxx:platform.bzl", "cxx_by_platform")
 
 def _symlink_all_source_files(ctx: AnalysisContext, subdir: str = "srcs"):
     """Create symlinks for all source files.
@@ -33,9 +34,29 @@ def _symlink_all_source_files(ctx: AnalysisContext, subdir: str = "srcs"):
 
     return ctx.actions.symlinked_dir("srcs", srcs)
 
-def _build_cflags_arg(cxx_toolchain_info: CxxToolchainInfo, extra_flags: list = []) -> list[str]:
+def _get_platform_specific_compiler_flags(ctx: AnalysisContext, platform_compiler_flags: list) -> list[str]:
+    """Return the platform-specific compiler flags.
+
+    Attrs:
+      ctx:
+        Analysis context.
+      platform_compiler_flags:
+        List of tuple of shape (regex, list[flags]).
+
+    Returns:
+      A list[str] of flags.
+    """
+    pcf = []
+    all_flags = cxx_by_platform(ctx, platform_compiler_flags)
+    for flags in all_flags:
+        pcf.extend([str(flag) for flag in flags])
+    return pcf
+
+def _build_cflags_arg(ctx: AnalysisContext, cxx_toolchain_info: CxxToolchainInfo, extra_flags: list = []) -> list[str]:
     """Build the list of flags for the CFLAGS argument.
       Attrs:
+        ctx:
+          Analysis context.
         cxx_toolchain_info: CxxToolchainInfo
           Information on the cxx toolchain.
         extra_flags: list[Any]
@@ -44,11 +65,15 @@ def _build_cflags_arg(cxx_toolchain_info: CxxToolchainInfo, extra_flags: list = 
       Returns:
           List[str]: list of C flags.
     """
-    return cxx_toolchain_info.c_compiler_info.compiler_flags + [str(flag) for flag in extra_flags]
+    return cxx_toolchain_info.c_compiler_info.compiler_flags + \
+           [str(flag) for flag in extra_flags] + \
+           _get_platform_specific_compiler_flags(ctx, ctx.attrs.platform_compiler_flags)
 
-def _build_cxxflags_arg(cxx_toolchain_info: CxxToolchainInfo, extra_flags: list = []) -> list[str]:
+def _build_cxxflags_arg(ctx: AnalysisContext, cxx_toolchain_info: CxxToolchainInfo, extra_flags: list = []) -> list[str]:
     """Build the list of flags for the CXXFLAGS argument.
       Attrs:
+        ctx:
+          Analysis context.
         cxx_toolchain_info: CxxToolchainInfo
           Information on the cxx toolchain.
         extra_flags: list[Any]
@@ -57,7 +82,11 @@ def _build_cxxflags_arg(cxx_toolchain_info: CxxToolchainInfo, extra_flags: list 
       Returns:
           List[str]: list of CXX flags.
     """
-    return cxx_toolchain_info.cxx_compiler_info.compiler_flags + [str(flag) for flag in extra_flags]
+    platform_compiler_flags = []
+    [platform_compiler_flags.extend([str(flag) for flag in flags]) for flags in cxx_by_platform(ctx, ctx.attrs.platform_compiler_flags)]
+    return cxx_toolchain_info.cxx_compiler_info.compiler_flags + \
+           [str(flag) for flag in extra_flags] + \
+           _get_platform_specific_compiler_flags(ctx, ctx.attrs.platform_compiler_flags)
 
 def _gnumake_impl(ctx: AnalysisContext) -> list:
     """Implementation of rule `gnumake`."""
@@ -69,10 +98,12 @@ def _gnumake_impl(ctx: AnalysisContext) -> list:
     srcs_dir = _symlink_all_source_files(ctx)
 
     cflags = _build_cflags_arg(
+        ctx,
         cxx_toolchain_info = cxx_toolchain_info,
         extra_flags = ctx.attrs.compiler_flags,
     )
     cxxflags = _build_cxxflags_arg(
+        ctx,
         cxx_toolchain_info = cxx_toolchain_info,
         extra_flags = ctx.attrs.compiler_flags,
     )
@@ -145,7 +176,7 @@ This is passed an an argument to `make` as `PREFIX=<value>`.
             default = "Makefile",
             doc = """
     The Makefile to use. This must contain the relative path to the Makefile.
-"""
+""",
         ),
         "targets": attrs.list(
             attrs.string(),


### PR DESCRIPTION
Fix #12: support platform-specific compiler flags.

This commit brings support for platform-specific compiler flags, through
the `platform_compiler_flags` attribute.

When used, specified flags will be added to both `CFLAGS` and `CXXFLAGS`.

An example which uses `platform_compiler_flags` has been added.
