### PR TITLE
Fix #11: create the install directory within the rule.

### DIFF
--- a/docs/gnumake/gnumake/rules.bzl.md
+++ b/docs/gnumake/gnumake/rules.bzl.md
@@ -38,6 +38,7 @@ def gnumake(
     tests: list[str] = _,
     _cxx_toolchain: str = _,
     _gnumake_toolchain: str = _,
+    _wrapped_make: str = _,
     args: list[str] = _,
     compiler_flags: list[str] = _,
     install_prefix: str = _,
@@ -61,6 +62,7 @@ def gnumake(
 * `tests`: a list of targets that provide tests for this one
 * `_cxx_toolchain`: CXX toolchain.
 * `_gnumake_toolchain`: GNUMake toolchain.
+* `_wrapped_make`: Wrapped make script.
 * `args`: A list of arguments to forward to the call to GNUMake.
 * `compiler_flags`: Flags to use when compiling.
 * `install_prefix`: Install prefix path, relative to where to install the result of the build. This is passed an an argument to `make` as `PREFIX=<value>`.

--- a/examples/custom_makefile_file/entry.makefile
+++ b/examples/custom_makefile_file/entry.makefile
@@ -1,9 +1,6 @@
 PREFIX?=${PWD}
 
-${PREFIX}:
-	mkdir -p $@
-
-${PREFIX}/hello.txt: ${PREFIX}
+${PREFIX}/hello.txt:
 	echo "hello world" > $@
 
 .PHONY: all

--- a/examples/makefile_platform_compiler_flags/Makefile
+++ b/examples/makefile_platform_compiler_flags/Makefile
@@ -1,4 +1,4 @@
 all: a.o
 
 install: a.o
-	mkdir ${PREFIX} && cp $^ ${PREFIX}/
+	cp $^ ${PREFIX}/

--- a/examples/makefile_with_compiler_flags/Makefile
+++ b/examples/makefile_with_compiler_flags/Makefile
@@ -1,4 +1,4 @@
 all: a.o
 
 install: a.o
-	mkdir ${PREFIX} && cp $^ ${PREFIX}/
+	cp $^ ${PREFIX}/

--- a/examples/simple_makefile/Makefile
+++ b/examples/simple_makefile/Makefile
@@ -1,9 +1,6 @@
 PREFIX ?= ${PWD}
 
-${PREFIX}:
-	mkdir -p $@
-
-${PREFIX}/out.txt: ${PREFIX}
+${PREFIX}/out.txt:
 	echo "hello world" > $@
 
 all: ${PREFIX}/out.txt

--- a/gnumake/BUCK
+++ b/gnumake/BUCK
@@ -24,6 +24,12 @@ http_archive(
     strip_prefix = "make-{version}".format(version = _VERSION),
 )
 
+sh_binary(
+    name = "wrapped_make",
+    main = "make.sh",
+    visibility = ["PUBLIC"],
+)
+
 genrule(
     name = "gnumake",
     srcs = [":src"],

--- a/gnumake/make.sh
+++ b/gnumake/make.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+_make_bin="$1"
+_install_dir="$2"
+
+shift 2
+
+set -x
+
+mkdir -p "${_install_dir}"
+
+"${_make_bin}" $@ CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}"


### PR DESCRIPTION
Fix #11: create the install directory within the rule.

This commit fixes #11 by creating the install directory.

Since we cannot use an output artifact in two called to `ctx.actions.run` (i.e.
`artifact.as_output()` must be used exactly once), we wrap the call to GNU Make
into a shell script, like other rules do.
