### PR TITLE
Fix #14: generate starlark documentation using `buck2 doc`.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,3 +39,6 @@ jobs:
         run: |
           buck2 build ...
 
+      - name: Check that documentation is synced
+        run: |
+          buck2 run docs:generate

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This repository implements a [Buck2] toolchain for using [GNU Make].
 [GNU Make] binaries are not downloaded from some source. Instead, the source code
 is built from the source.
 
+_TL;DR_: See [`gnumake`](docs/gnumake/gnumake/rules.bzl.md#gnumake).
+
 ## Dependencies
 
 ### `python_bootstrap`, `genrule` and `cxx` toolchains.

--- a/docs/BUCK
+++ b/docs/BUCK
@@ -1,0 +1,4 @@
+sh_binary(
+    name = "generate",
+    main = "generate.sh",
+)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# Documentation
+
+## Generating the documentation
+
+To generate the documentation, run the following:
+
+```shell
+$ buck2 run //docs:generate -- generate
+```

--- a/docs/generate.sh
+++ b/docs/generate.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -e
+
+buck2 docs starlark \
+  --format markdown_files \
+  --markdown-files-starlark-subdir "" \
+  --markdown-files-destination-dir "${PWD}/docs/" \
+  -- @gnumake//gnumake:rules.bzl \
+     @gnumake//gnumake:toolchain_info.bzl
+
+if ! [ "$1" = "generate" ]; then
+  if [ -d ".git" ]; then
+    if ! git diff --exit-code; then
+      echo "Documentation is out of sync."
+      exit 1
+    fi
+  elif [ -d ".sl" ]; then
+    if [ -n "$(sl diff)" ]; then
+      echo "Documentation is out of sync."
+      exit 1
+    fi
+  else
+    echo "Unknown vcs."
+    exit 1
+  fi
+fi
+exit 0

--- a/docs/gnumake/gnumake/rules.bzl.md
+++ b/docs/gnumake/gnumake/rules.bzl.md
@@ -1,0 +1,78 @@
+## CxxToolchainInfo
+
+```python
+CxxToolchainInfo: provider_callable
+```
+
+---
+## GNUMakeToolchainInfo
+
+```python
+GNUMakeToolchainInfo: provider_callable
+```
+
+---
+## cxx\_by\_platform
+
+```python
+def cxx_by_platform(
+    ctx: context,
+    xs: list[(str, typing.Any)]
+) -> list[typing.Any]
+```
+
+---
+## gnumake
+
+```python
+def gnumake(
+    *,
+    name: str,
+    default_target_platform: None | str = _,
+    target_compatible_with: list[str] = _,
+    compatible_with: list[str] = _,
+    exec_compatible_with: list[str] = _,
+    visibility: list[str] = _,
+    within_view: list[str] = _,
+    metadata: opaque_metadata = _,
+    tests: list[str] = _,
+    _cxx_toolchain: str = _,
+    _gnumake_toolchain: str = _,
+    args: list[str] = _,
+    compiler_flags: list[str] = _,
+    install_prefix: str = _,
+    makefile: str = _,
+    platform_compiler_flags: list[(str, list[str])] = _,
+    srcs: list[str],
+    targets: list[str] = _
+) -> None
+```
+
+#### Parameters
+
+* `name`: name of the target
+* `default_target_platform`: specifies the default target platform, used when no platforms are specified on the command line
+* `target_compatible_with`: a list of constraints that are required to be satisfied for this target to be compatible with a configuration
+* `compatible_with`: a list of constraints that are required to be satisfied for this target to be compatible with a configuration
+* `exec_compatible_with`: a list of constraints that are required to be satisfied for this target to be compatible with an execution platform
+* `visibility`: a list of visibility patterns restricting what targets can depend on this one
+* `within_view`: a list of visibility patterns restricting what this target can depend on
+* `metadata`: a key-value map of metadata associated with this target
+* `tests`: a list of targets that provide tests for this one
+* `_cxx_toolchain`: CXX toolchain.
+* `_gnumake_toolchain`: GNUMake toolchain.
+* `args`: A list of arguments to forward to the call to GNUMake.
+* `compiler_flags`: Flags to use when compiling.
+* `install_prefix`: Install prefix path, relative to where to install the result of the build. This is passed an an argument to `make` as `PREFIX=<value>`.
+* `makefile`: The Makefile to use. This must contain the relative path to the Makefile.
+* `platform_compiler_flags`: Flags to use when compiling.
+* `srcs`: Input source.
+* `targets`: A list of targets to produce.
+
+
+---
+## native
+
+```python
+native: struct(..)
+```

--- a/docs/gnumake/gnumake/toolchain_info.bzl.md
+++ b/docs/gnumake/gnumake/toolchain_info.bzl.md
@@ -1,0 +1,12 @@
+## GNUMakeToolchainInfo
+
+```python
+GNUMakeToolchainInfo: provider_callable
+```
+
+---
+## native
+
+```python
+native: struct(..)
+```


### PR DESCRIPTION
Fix #14: generate starlark documentation using `buck2 doc`.

This commit adds a small shell script for generating the documentation of
starlark rules in Markdown using [`buck2 doc`].

[`buck2 doc`]: https://buck2.build/docs/users/commands/docs/#buck-docs
