### PR TITLE
#19: implement `out_binaries` and `out_binary_dir`.

### DIFF
--- a/examples/makefile_with_binary/BUCK
+++ b/examples/makefile_with_binary/BUCK
@@ -1,0 +1,9 @@
+load("@gnumake//gnumake:rules.bzl", "gnumake")
+
+gnumake(
+    name = "example",
+    srcs = ["Makefile", "a.c"],
+    targets = ["all"],
+    out_binaries = ["a"],
+    out_binary_dir = "custom_bin_path",
+)

--- a/examples/makefile_with_binary/Makefile
+++ b/examples/makefile_with_binary/Makefile
@@ -1,0 +1,13 @@
+a: a.o
+
+a.o: a.c
+
+${PREFIX}/custom_bin_path/a: a ${PREFIX}/custom_bin_path
+	cp $< $@
+
+${PREFIX}/custom_bin_path:
+	mkdir $@
+
+all: ${PREFIX}/custom_bin_path/a
+
+.PHONY: all

--- a/examples/makefile_with_binary/a.c
+++ b/examples/makefile_with_binary/a.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main() {
+  puts("hello world");
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
#19: implement `out_binaries` and `out_binary_dir`.

This commit implements the following two attributes to the `gnumake` rule:
  - `out_binaries`: output executable binaries. Relative to `out_binary_dir`. Default: []
  - `out_binary_dir`: output subdirectory that contains executable binaries. Relative to the install directory. Default: `bin`.
