### PR TITLE
#19: implement `out_static_libs` and `out_lib_dir`.

### DIFF
--- a/docs/gnumake/gnumake/rules.bzl.md
+++ b/docs/gnumake/gnumake/rules.bzl.md
@@ -45,6 +45,8 @@ def gnumake(
     makefile: str = _,
     out_binaries: list[str] = _,
     out_binary_dir: str = _,
+    out_lib_dir: str = _,
+    out_static_libs: list[str] = _,
     platform_compiler_flags: list[(str, list[str])] = _,
     srcs: list[str],
     targets: list[str] = _
@@ -71,6 +73,8 @@ def gnumake(
 * `makefile`: The Makefile to use. This must contain the relative path to the Makefile.
 * `out_binaries`: Filenames of output executable binaries. These files will be fetched from the `out_binary_dir` directory.
 * `out_binary_dir`: Name of the subdirectory that contains the executable binary files.
+* `out_lib_dir`: Name of the subdirectory that contains the library files.
+* `out_static_libs`: Filenames of output static libraries. These files will be fetched from the `out_lib_dir` directory.
 * `platform_compiler_flags`: Flags to use when compiling.
 * `srcs`: Input source.
 * `targets`: A list of targets to produce.

--- a/examples/makefile_with_static_lib/BUCK
+++ b/examples/makefile_with_static_lib/BUCK
@@ -1,0 +1,9 @@
+load("@gnumake//gnumake:rules.bzl", "gnumake")
+
+gnumake(
+    name = "example",
+    srcs = ["Makefile", "a.c"],
+    targets = ["all"],
+    out_static_libs = ["a.a"],
+    out_lib_dir = "custom_static_libs",
+)

--- a/examples/makefile_with_static_lib/Makefile
+++ b/examples/makefile_with_static_lib/Makefile
@@ -1,0 +1,14 @@
+a.a: a.o
+	clang -static -o $@ $^
+
+a.o: a.c
+
+${PREFIX}/custom_static_libs/a.a: a.a ${PREFIX}/custom_static_libs
+	cp $< $@
+
+${PREFIX}/custom_static_libs:
+	mkdir $@
+
+all: ${PREFIX}/custom_static_libs/a.a
+
+.PHONY: all

--- a/examples/makefile_with_static_lib/a.c
+++ b/examples/makefile_with_static_lib/a.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main() {
+  puts("hello world");
+
+  return EXIT_SUCCESS;
+}

--- a/gnumake/rules.bzl
+++ b/gnumake/rules.bzl
@@ -88,44 +88,105 @@ def _build_cxxflags_arg(ctx: AnalysisContext, cxx_toolchain_info: CxxToolchainIn
            [str(flag) for flag in extra_flags] + \
            _get_platform_specific_compiler_flags(ctx, ctx.attrs.platform_compiler_flags)
 
-def _fetch_out_executable_binaries(ctx: AnalysisContext, install_dir: Artifact) -> list[Artifact]:
+def _move_artifacts(
+        ctx: AnalysisContext,
+        install_dir: Artifact,
+        sub_dir: str,
+        filenames: list[str],
+        identifier_format: str) -> (list[Artifact], dict):
+    """Moves files from `install_dir`/`sub_dir`.
+
+    Attrs:
+      ctx:
+        Analysis context.
+      install_dir:
+        Install directory.
+      sub_dir:
+        Sub directory within `install_dir`.
+      filenames:
+        List of file names to move.
+      identifier_format:
+        ctx.actions.run identifier format. Must contain `label`, `i`
+        and `filename`.
+
+    Returns:
+      List of artifacts and dict of DefaultInfo provider.
+    """
+
+    out_files = []
+    sub_targets = {}
+    for i in range(len(filenames)):
+        filename = filenames[i]
+        src = cmd_args(install_dir, format = "{{}}/{sub_dir}/{filename}".format(
+            sub_dir = sub_dir,
+            filename = filename,
+        ))
+        out = ctx.actions.declare_output("{sub_dir}_{i}".format(
+            sub_dir = sub_dir,
+            i = i,
+        ), filename)
+        ctx.actions.run(
+            cmd_args(["mv", src, out.as_output()]),
+            category = "gnumake",
+            identifier = identifier_format.format(
+                label = ctx.label,
+                i = i,
+                filename = filename,
+            ),
+        )
+        out_files.append(out)
+        sub_targets[filename] = [
+            DefaultInfo(default_output = out),
+        ]
+
+    return out_files, sub_targets
+
+def _fetch_out_executable_binaries(ctx: AnalysisContext, install_dir: Artifact) -> (list[Artifact], dict):
     """Fetches the output executable binaries, using `attr.output_binary_dir`
     and `attr.out_binaries`.
 
     Attrs:
       ctx:
         Analysis context.
+      install_dir:
+        Install directory.
 
     Returns:
-      List of artifacts. This list may be empty."""
+      List of artifacts and dictionary of providers. This list may be empty."""
 
-    if len(ctx.attrs.out_binaries) == 0:
-        return []
+    outs, sub_targets = _move_artifacts(
+        ctx = ctx,
+        install_dir = install_dir,
+        sub_dir = ctx.attrs.out_binary_dir,
+        filenames = ctx.attrs.out_binaries,
+        identifier_format = "{label}/out_binaries[{i}]={filename}",
+    )
 
-    out_binaries = []
-    i = 0
-    for binary_filename in ctx.attrs.out_binaries:
-        src = cmd_args(install_dir, format = "{{}}/{bin_path}/{binary_filename}".format(
-            bin_path = ctx.attrs.out_binary_dir,
-            binary_filename = binary_filename,
-        ))
-        out = ctx.actions.declare_output("bin_{i}/{binary_filename}".format(
-            i = i,
-            binary_filename = binary_filename,
-        ))
-        ctx.actions.run(
-            cmd_args(["mv", src, out.as_output()]),
-            category = "gnumake",
-            identifier = "{label}/out_binaries[{i}]={binary_filename}".format(
-                label = ctx.label,
-                i = i,
-                binary_filename = binary_filename,
-            ),
-        )
-        out_binaries.append(out)
-        i += 1
+    for i in range(len(ctx.attrs.out_binaries)):
+        sub_targets[ctx.attrs.out_binaries[i]].append(RunInfo(cmd_args(outs[i])))
 
-    return out_binaries
+    return outs, sub_targets
+
+def _fetch_out_static_libraries(ctx: AnalysisContext, install_dir: Artifact) -> (list[Artifact], dict):
+    """Fetches the output static libraries, using `attr.out_lib_dir`
+    and `attr.out_static_libs`.
+
+    Attrs:
+      ctx:
+        Analysis context.
+      install_dir:
+        Install directory.
+
+    Returns:
+      List of artifacts and dictionary of providers. This list may be empty."""
+
+    return _move_artifacts(
+        ctx = ctx,
+        install_dir = install_dir,
+        sub_dir = ctx.attrs.out_lib_dir,
+        filenames = ctx.attrs.out_static_libs,
+        identifier_format = "{label}/out_static_libs[{i}]={filename}",
+    )
 
 def _gnumake_impl(ctx: AnalysisContext) -> list:
     """Implementation of rule `gnumake`."""
@@ -165,31 +226,26 @@ def _gnumake_impl(ctx: AnalysisContext) -> list:
         exe = ctx.attrs._wrapped_make[RunInfo],
     )
 
-    out_binaries = _fetch_out_executable_binaries(
+    out_binaries, out_binaries_sub_targets = _fetch_out_executable_binaries(
         ctx = ctx,
         install_dir = install_dir,
     )
 
-    run_infos = {}
-    for i in range(len(ctx.attrs.out_binaries)):
-        run_infos[ctx.attrs.out_binaries[i]] = [
-            DefaultInfo(default_output = out_binaries[i]),
-            RunInfo(cmd_args(out_binaries[i])),
-        ]
+    out_static_libs, out_static_libs_sub_targets = _fetch_out_static_libraries(
+        ctx = ctx,
+        install_dir = install_dir,
+    )
 
-    if len(out_binaries) == 0:
-        return [
-            DefaultInfo(
-                default_output = install_dir,
-            ),
-        ]
-    else:
-        return [
-            DefaultInfo(
-                default_outputs = [install_dir] + out_binaries,
-                sub_targets = run_infos,
-            ),
-        ]
+    sub_targets = {}
+    sub_targets.update(out_binaries_sub_targets)
+    sub_targets.update(out_static_libs_sub_targets)
+
+    return [
+        DefaultInfo(
+            default_outputs = [install_dir] + out_binaries + out_static_libs,
+            sub_targets = sub_targets,
+        ),
+    ]
 
 def _gnumake_attributes() -> dict[str, Attr]:
     return {
@@ -247,6 +303,20 @@ This is passed an an argument to `make` as `PREFIX=<value>`.
             default = ["", "install"],
             doc = """
     A list of targets to produce.
+""",
+        ),
+        "out_lib_dir": attrs.string(
+            default = "lib",
+            doc = """
+    Name of the subdirectory that contains the library files.
+""",
+        ),
+        "out_static_libs": attrs.list(
+            attrs.string(),
+            default = [],
+            doc = """
+    Filenames of output static libraries. These files will be fetched
+    from the `out_lib_dir` directory.
 """,
         ),
         "out_binary_dir": attrs.string(


### PR DESCRIPTION
#19: implement `out_static_libs` and `out_lib_dir`.

This commit implements the following two attributes to the `gnumake` rule:
  - `out_static_libs`: output static libraries. Relative to `out_lib_dir`. Default: []
  - `out_lib_dir`: output subdirectory that contains static and shared libraries. Relative to the install directory. Default: `lib`.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/zadlg/buck2_rules_gnumake/pull/28).
* #31
* #29
* __->__ #28