### PR TITLE
#19: implement `out_shared_libs`.

### DIFF
--- a/docs/gnumake/gnumake/rules.bzl.md
+++ b/docs/gnumake/gnumake/rules.bzl.md
@@ -46,6 +46,7 @@ def gnumake(
     out_binaries: list[str] = _,
     out_binary_dir: str = _,
     out_lib_dir: str = _,
+    out_shared_libs: list[str] = _,
     out_static_libs: list[str] = _,
     platform_compiler_flags: list[(str, list[str])] = _,
     srcs: list[str],
@@ -74,6 +75,7 @@ def gnumake(
 * `out_binaries`: Filenames of output executable binaries. These files will be fetched from the `out_binary_dir` directory.
 * `out_binary_dir`: Name of the subdirectory that contains the executable binary files.
 * `out_lib_dir`: Name of the subdirectory that contains the library files.
+* `out_shared_libs`: Filenames of output shared libraries. These files will be fetched from the `out_lib_dir` directory.
 * `out_static_libs`: Filenames of output static libraries. These files will be fetched from the `out_lib_dir` directory.
 * `platform_compiler_flags`: Flags to use when compiling.
 * `srcs`: Input source.

--- a/examples/makefile_with_shared_lib/BUCK
+++ b/examples/makefile_with_shared_lib/BUCK
@@ -1,0 +1,9 @@
+load("@gnumake//gnumake:rules.bzl", "gnumake")
+
+gnumake(
+    name = "example",
+    srcs = ["Makefile", "a.c"],
+    targets = ["all"],
+    out_shared_libs = ["a.so"],
+    out_lib_dir = "custom_shared_libs",
+)

--- a/examples/makefile_with_shared_lib/Makefile
+++ b/examples/makefile_with_shared_lib/Makefile
@@ -1,0 +1,14 @@
+a.so: a.o
+	clang -shared -o $@ $^
+
+a.o: a.c
+
+${PREFIX}/custom_shared_libs/a.so: a.so ${PREFIX}/custom_shared_libs
+	cp $< $@
+
+${PREFIX}/custom_shared_libs:
+	mkdir $@
+
+all: ${PREFIX}/custom_shared_libs/a.so
+
+.PHONY: all

--- a/examples/makefile_with_shared_lib/a.c
+++ b/examples/makefile_with_shared_lib/a.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main() {
+  puts("hello world");
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
#19: implement `out_shared_libs`.

This commit implements the following attribute to the `gnumake` rule:
  - `out_shared_libs`: output shared libraries. Relative to `out_lib_dir`. Default: []

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/zadlg/buck2_rules_gnumake/pull/29).
* #31
* __->__ #29