### PR TITLE
Fix #25: run `buildifier`.

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,27 @@
+name: Linter tests
+
+on:
+  push:
+    branches:
+      - "*"
+      - "!sapling-pr-archive-*"
+
+jobs:
+  buildifier:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Setup Go environment
+        uses: actions/setup-go@v5.0.0
+
+      - name: Install buildifier
+        run: go install github.com/bazelbuild/buildtools/buildifier@latest
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run buildifier
+        run: |
+          buildifier -r -mode check .
+          find . -name BUCK -exec buildifier -mode check {} \;


### PR DESCRIPTION
Fix #25: run `buildifier`.

This commit adds a GitHub Action job for running [`buildifier`] on Starlark
files and `BUCK` files.

[`buildifier`]: https://github.com/bazelbuild/buildtools/tree/master/buildifier
