### PR TITLE
#19: implement `out_include_dir`.

### DIFF
--- a/docs/gnumake/gnumake/rules.bzl.md
+++ b/docs/gnumake/gnumake/rules.bzl.md
@@ -45,6 +45,7 @@ def gnumake(
     makefile: str = _,
     out_binaries: list[str] = _,
     out_binary_dir: str = _,
+    out_include_dir: str = _,
     out_lib_dir: str = _,
     out_shared_libs: list[str] = _,
     out_static_libs: list[str] = _,
@@ -74,6 +75,7 @@ def gnumake(
 * `makefile`: The Makefile to use. This must contain the relative path to the Makefile.
 * `out_binaries`: Filenames of output executable binaries. These files will be fetched from the `out_binary_dir` directory.
 * `out_binary_dir`: Name of the subdirectory that contains the executable binary files.
+* `out_include_dir`: Name of the subdirectory that contains the header files.
 * `out_lib_dir`: Name of the subdirectory that contains the library files.
 * `out_shared_libs`: Filenames of output shared libraries. These files will be fetched from the `out_lib_dir` directory.
 * `out_static_libs`: Filenames of output static libraries. These files will be fetched from the `out_lib_dir` directory.

--- a/examples/makefile_with_includes/BUCK
+++ b/examples/makefile_with_includes/BUCK
@@ -1,0 +1,8 @@
+load("@gnumake//gnumake:rules.bzl", "gnumake")
+
+gnumake(
+    name = "example",
+    srcs = ["Makefile", "myheader.h"],
+    targets = ["all"],
+    out_include_dir = "custom_include_dir",
+)

--- a/examples/makefile_with_includes/Makefile
+++ b/examples/makefile_with_includes/Makefile
@@ -1,0 +1,12 @@
+${PREFIX}/custom_include_dir/mylib/myheader.h: myheader.h ${PREFIX}/custom_include_dir/mylib
+	cp $< $@
+
+${PREFIX}/custom_include_dir/mylib: ${PREFIX}/custom_include_dir
+	mkdir $@
+
+${PREFIX}/custom_include_dir:
+	mkdir $@
+
+all: ${PREFIX}/custom_include_dir/mylib/myheader.h
+
+.PHONY: all

--- a/examples/makefile_with_includes/myheader.h
+++ b/examples/makefile_with_includes/myheader.h
@@ -1,0 +1,3 @@
+#pragma once
+
+extern void mylib(void);


### PR DESCRIPTION
#19: implement `out_include_dir`.

This commit implements the following attribute to the `gnumake` rule:
  - `out_include_dir`: output include directory. Relative to the install directory.
