### PR TITLE
Fix #35: forward CC and CXX from `CxxToolchain` to GNU Make.

### DIFF
--- a/gnumake/attributes.bzl
+++ b/gnumake/attributes.bzl
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@prelude//cxx:cxx_toolchain_types.bzl", "CxxToolchainInfo")
 load(":providers.bzl", "GNUMakeToolchainInfo")
 
 def gnumake_rule_get_attributes() -> dict:
@@ -132,6 +133,7 @@ This is passed an an argument to `make` as `PREFIX=<value>`.
         "_cxx_toolchain": attrs.default_only(
             attrs.toolchain_dep(
                 default = "@toolchains//:cxx",
+                providers = [CxxToolchainInfo],
             ),
             doc = """
     CXX toolchain.

--- a/gnumake/rules.bzl
+++ b/gnumake/rules.bzl
@@ -282,6 +282,8 @@ def _gnumake_impl(ctx: AnalysisContext) -> list[Provider]:
     args.add(["-C", srcs_dir])
     args.add(["-f", ctx.attrs.makefile])
     args.add(cmd_args(cmd_args(install_dir.as_output()).relative_to(srcs_dir), format = "PREFIX={}"))
+    args.add(cmd_args(cxx_toolchain_info.c_compiler_info.compiler, format = "CC={}"))
+    args.add(cmd_args(cxx_toolchain_info.cxx_compiler_info.compiler, format = "CXX={}"))
     args.add(ctx.attrs.args)
     args.add(ctx.attrs.targets)
     env = {


### PR DESCRIPTION
Fix #35: forward CC and CXX from `CxxToolchain` to GNU Make.

This commit picks the C compiler and C++ compiler from the current C++
toolchain and forwards them to GNU Make through the Make variable `CC`
and `CXX`.
